### PR TITLE
Use WebTest middleware to have a cleaner Web testing tooling => Must adapt every web tests...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ guppy
 junitxml
 jwcrypto==0.7.0
 requests-toolbelt
+WebTest==2.0.35


### PR DESCRIPTION
This also allow to have beaker integration even in tests, we can't have it with current implementation
init_context context manager is only needed when doing database work outside http requests

WARNING : All BP unit test must be adapted as well